### PR TITLE
keeping compatibility with slighty older versions of python

### DIFF
--- a/src/modules/base.py
+++ b/src/modules/base.py
@@ -10,7 +10,7 @@ class DofusModule:
             print("Broken buffers, flushing")
             network.flush_buffers()
             return
-        handle = f"handle_{packet["__type__"]}"
+        handle = f"handle_{packet['__type__']}"
         if hasattr(self, handle) and callable(handler := getattr(self, handle)):
             if packet is None:
                 packet = protocol.readMsg(msg)


### PR DESCRIPTION
Hi, I'm currently using 3.11.2 on my current machine and it doesn't quite support double quotes inside the string formatting syntax.. could we perhaps change the inner double quotes to single quote? 